### PR TITLE
Use linked hash map in translations list to retain ordering

### DIFF
--- a/src/main/kotlin/com/miquido/stringstranslator/conversion/PluralStringsToSpreadsheetConverter.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/conversion/PluralStringsToSpreadsheetConverter.kt
@@ -23,7 +23,7 @@ class PluralStringsToSpreadsheetConverter(platform: Platform, baseLanguageCode: 
         val baseLangValuesSize = stringsModel
                 .pluralString[baseLanguageCode]
                 ?.pluralStringValue?.size ?: 0
-        fillDataForRemainingLanguages(PluralStringSetModel(HashMap(mapExceptDefaultLanguage)), baseLangValuesSize)
+        fillDataForRemainingLanguages(PluralStringSetModel(LinkedHashMap(mapExceptDefaultLanguage)), baseLangValuesSize)
         return workbook
     }
 

--- a/src/main/kotlin/com/miquido/stringstranslator/conversion/SingleStringsToSpreadsheetConverter.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/conversion/SingleStringsToSpreadsheetConverter.kt
@@ -24,7 +24,7 @@ class SingleStringsToSpreadsheetConverter(platform: Platform, baseLanguageCode: 
                 .singleString
                 .filterNot { it.key == baseLanguageCode }
         fillDataForRemainingLanguages(
-                SingleStringSetModel(HashMap(mapExceptDefaultLanguage)),
+                SingleStringSetModel(LinkedHashMap(mapExceptDefaultLanguage)),
                 baseLangValuesSize
         )
         return workbook

--- a/src/main/kotlin/com/miquido/stringstranslator/model/parsing/ParsedStringTranslationModel.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/model/parsing/ParsedStringTranslationModel.kt
@@ -5,22 +5,22 @@ import com.miquido.stringstranslator.model.translations.PluralTranslationModel
 import com.miquido.stringstranslator.model.translations.TranslationModel
 
 data class ParsedStringTranslationModel(
-        val singleStringSet: SingleStringSetModel = SingleStringSetModel(hashMapOf()),
-        val pluralStringSet: PluralStringSetModel = PluralStringSetModel(hashMapOf())
+        val singleStringSet: SingleStringSetModel = SingleStringSetModel(linkedMapOf()),
+        val pluralStringSet: PluralStringSetModel = PluralStringSetModel(linkedMapOf())
 )
 
 data class SingleStringSetModel(
-        val singleString: HashMap<LanguageCode, SingleStringValuesModel> = hashMapOf()
+        val singleString: LinkedHashMap<LanguageCode, SingleStringValuesModel> = linkedMapOf()
 )
 
 data class SingleStringValuesModel(
-        val singleStringValue: HashMap<String, TranslationModel> = hashMapOf()
+        val singleStringValue: LinkedHashMap<String, TranslationModel> = linkedMapOf()
 )
 
 data class PluralStringSetModel(
-        val pluralString: HashMap<LanguageCode, PluralStringValuesModel> = hashMapOf()
+        val pluralString: LinkedHashMap<LanguageCode, PluralStringValuesModel> = linkedMapOf()
 )
 
 data class PluralStringValuesModel(
-        val pluralStringValue: HashMap<String, PluralTranslationModel> = hashMapOf()
+        val pluralStringValue: LinkedHashMap<String, PluralTranslationModel> = linkedMapOf()
 )

--- a/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/AndroidStringParser.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/AndroidStringParser.kt
@@ -51,7 +51,7 @@ class AndroidStringParser : StringParser, KoinComponent {
     }
 
     private fun takePluralStringsFromFile(path: StringsFilePath): PluralStringValuesModel {
-        val pluralStringModel = HashMap<String, PluralTranslationModel>()
+        val pluralStringModel = LinkedHashMap<String, PluralTranslationModel>()
 
         parsePluralStringResources(path.value).stringsList.forEach { stringModel ->
             val pluralsQualifierMap: HashMap<PluralQualifier, String> = hashMapOf()

--- a/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/IosStringParser.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/IosStringParser.kt
@@ -18,8 +18,8 @@ class IosStringParser : StringParser, KoinComponent {
     override fun parseStringsFile(inputStringPath: String, baseLanguageCode: String)
             : ParsedStringTranslationModel {
 
-        val singleStringsMap = HashMap<LanguageCode, SingleStringValuesModel>()
-        val pluralStringsMap = HashMap<LanguageCode, PluralStringValuesModel>()
+        val singleStringsMap = LinkedHashMap<LanguageCode, SingleStringValuesModel>()
+        val pluralStringsMap = LinkedHashMap<LanguageCode, PluralStringValuesModel>()
         File(inputStringPath).walkTopDown()
                 .map { it.invariantSeparatorsPath }
                 .filter { it.matches(Regex(STRING_FILE_PATTERN)) }
@@ -44,7 +44,7 @@ class IosStringParser : StringParser, KoinComponent {
     }
 
     private fun parseValuesForPluralsFile(filePath: StringsFilePath): PluralStringValuesModel {
-        val pluralStringsValuesModel = HashMap<String, PluralTranslationModel>()
+        val pluralStringsValuesModel = LinkedHashMap<String, PluralTranslationModel>()
         (PropertyListParser.parse(filePath.value) as NSDictionary).forEach {
             val pluralsMap = hashMapOf<PluralQualifier, String>()
             val translationModel = PluralTranslationModel(it.key, pluralsMap)
@@ -88,7 +88,7 @@ class IosStringParser : StringParser, KoinComponent {
 
         val iosStringsModel = IosSingleStringsModel()
         iosStringsModel.load(File(filePath.value))
-        val singleStringsValuesModel = HashMap<String, TranslationModel>()
+        val singleStringsValuesModel = LinkedHashMap<String, TranslationModel>()
         iosStringsModel
                 .map {
                     Pair(it.key, IosTranslationModel(it.key, it.value))

--- a/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/WebStringParser.kt
+++ b/src/main/kotlin/com/miquido/stringstranslator/parsing/strings/WebStringParser.kt
@@ -53,7 +53,7 @@ class WebStringParser : StringParser, KoinComponent {
     }
 
     private fun takePluralStringsFromFile(path: StringsFilePath): PluralStringValuesModel {
-        val pluralStringModel = HashMap<String, PluralTranslationModel>()
+        val pluralStringModel = LinkedHashMap<String, PluralTranslationModel>()
 
         parsePluralStringResources(path.value).forEach { stringWebModel ->
             val pluralsQualifierMap: HashMap<PluralQualifier, String> = hashMapOf()


### PR DESCRIPTION
Current implementation used a regular HashMap for storing translation lists. This PR introduces a change to LinkedHashMap to retain the string ordering. 